### PR TITLE
change compact display selector to adjust font size only on the body …

### DIFF
--- a/resources/scss/theme/layout/_display.scss
+++ b/resources/scss/theme/layout/_display.scss
@@ -5,7 +5,7 @@
 
     @media (min-width: 992px)
     {
-        *
+        &
         {
             font-size: $fontsize;
         }


### PR DESCRIPTION
When currently using the `body.display--compact` class, it makes ALL child elements having the font-size. This means that all get overridden unless specifically set in css.

I think this should be more like how bootstrap does set the website font-size, which can be seen in `_reboot.scss`:
```scss
body {
  // Make the `body` use the `font-size-root`
  font-family: $font-family-base;
  font-size: $font-size-base;
  line-height: $line-height-base;
  // Go easy on the eyes and use something other than `#000` for text
  color: $body-color;
  // By default, `<body>` has no `background-color` so we set one as a best practice.
  background-color: $body-bg;
}
```

Should use the same way if you want global font-size adjustments. This pull request does exactly that.