### PR TITLE
fix the link inside an alert is not clickable

### DIFF
--- a/resources/js/theme/alert.js
+++ b/resources/js/theme/alert.js
@@ -1,0 +1,9 @@
+var onAlertLinkClick = function () {
+    $('.alert a').click(function (e) {
+        e.stopPropagation()
+    })
+};
+
+$(document).ready(function () {
+    onAlertLinkClick();
+});

--- a/resources/views/partials/metadata.twig
+++ b/resources/views/partials/metadata.twig
@@ -51,6 +51,7 @@
 {{ asset_add("scripts.js", "pyrocms.theme.accelerant::js/theme/prompt.js") }}
 {{ asset_add("scripts.js", "pyrocms.theme.accelerant::js/theme/push.js") }}
 {{ asset_add("scripts.js", "pyrocms.theme.accelerant::js/theme/search.js") }}
+{{ asset_add("scripts.js", "pyrocms.theme.accelerant::js/theme/alert.js") }}
 
 <style type="text/css">
     {{ asset_inline("theme.css") }}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45572261/85126535-5dce4a00-b236-11ea-9ac3-7b03b7e47fd7.png)

when clicking on the alert link the alert box disappears before redirecting to the uninstall route